### PR TITLE
ConnectionState understanding

### DIFF
--- a/mq.go
+++ b/mq.go
@@ -20,7 +20,6 @@ const (
 	statusReadyForReconnect int32 = 0
 	statusReconnecting      int32 = 1
 
-	ConnectionStateUndefined    ConnectionState = 0
 	ConnectionStateDisconnected ConnectionState = 1
 	ConnectionStateConnected    ConnectionState = 2
 	ConnectionStateConnecting   ConnectionState = 3
@@ -86,7 +85,7 @@ func New(config Config) (MQ, error) {
 		producers:            newProducersRegistry(len(config.Producers)),
 		state:                new(int32),
 	}
-	atomic.StoreInt32(mq.state, int32(ConnectionStateUndefined))
+	atomic.StoreInt32(mq.state, int32(ConnectionStateDisconnected))
 
 	if err := mq.connect(); err != nil {
 		return nil, err

--- a/mq_test.go
+++ b/mq_test.go
@@ -535,7 +535,7 @@ func TestMq_ConnectionState(t *testing.T) {
 		name     string
 		expected ConnectionState
 	}{
-		{name: "status undefined", expected: ConnectionStateUndefined},
+		{name: "status disconnected", expected: ConnectionStateDisconnected},
 		{name: "status changed", expected: ConnectionStateConnecting},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
There are cases when you need to understand what's going on with your MQ connection. 
In my case: 
i need to understand, that there's no problem with mq connection from my app side and make signal if there are problems with that. 

There's no method in current version, that allows you to monitor connection state.  Of course we should balance between opening everything and nothing. That's why i added few constants to show connection state. 

You may point me, that there's errors channel opened outside `MQ.Error()`.  But here's the question: how to understand that disconnect / connection problems are not an issues anymore? 
