### PR TITLE
Update module path, amqp091 dependency

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/cheshir/go-mq"
+	"github.com/cheshir/go-mq/v2"
 	"gopkg.in/yaml.v1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cheshir/go-mq
+module github.com/cheshir/go-mq/v2
 
 go 1.16
 
@@ -6,6 +6,6 @@ require (
 	github.com/NeowayLabs/wabbit v0.0.0-20210927194032-73ad61d1620e
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
-	github.com/rabbitmq/amqp091-go v1.5.0
+	github.com/rabbitmq/amqp091-go v1.6.1
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )


### PR DESCRIPTION
This allows `go get` to pull version 2 of the module. Currently, attempting to upgrade to v2 of the module produces the following output:

```
go get github.com/cheshir/go-mq/v2
go: module github.com/cheshir/go-mq@upgrade found (v1.2.0), but does not contain package github.com/cheshir/go-mq/v2
```

Calling `go get` without `/v2` installs v1.2.0.

On my fork (master branch) I created a tagged version v2.0.1 with the same changes (but updated module path), and was able to run `go get -v github.com/calloway-jacob/go-mq/v2`.

If this PR is accepted, I think it will also need a tag.
